### PR TITLE
fix: php-amqplib conflict with php7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": "^7.4",
     "ext-json": "*",
     "illuminate/support": "^6.0",
-    "php-amqplib/php-amqplib": "^2.11"
+    "php-amqplib/php-amqplib": "v2.11.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
- Fixes the php-amqplib package's version to `2.11.0` since `2.11.1` conflicts with PHP7.4