### PR TITLE
chore: illuminate support version upgraded to ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
   "require": {
     "php": "^7.4",
     "ext-json": "*",
-    "illuminate/support": "^6.0",
+    "illuminate/support": "^7.0",
     "php-amqplib/php-amqplib": "v2.11.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",
-    "orchestra/testbench": "^4.0",
+    "orchestra/testbench": "^5.0",
     "phpunit/phpunit": "^8.5",
     "squizlabs/php_codesniffer": "^3.5"
   },


### PR DESCRIPTION
Changes
---

- illuminate/support version changed from 6.0 to ^7.0
- orchestra/testbench changed from 4.0 to 5.0

Outcome
---
Package will be compatible with laravel 7