### PR TITLE
feat: upgrade to laravel-8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kunalvarma05/laravel-rabbitmq",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Work with RabbitMQ in Laravel.",
   "keywords": [
     "amqp",
@@ -20,13 +20,13 @@
   "require": {
     "php": "^7.4",
     "ext-json": "*",
-    "illuminate/support": "^7.0",
+    "illuminate/support": "^8.28",
     "php-amqplib/php-amqplib": "v2.11.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",
-    "orchestra/testbench": "^5.0",
-    "phpunit/phpunit": "^8.5",
+    "orchestra/testbench": "^6.11.0",
+    "phpunit/phpunit": "^9.4.0",
     "squizlabs/php_codesniffer": "^3.5"
   },
   "autoload": {


### PR DESCRIPTION
Version Upgrade
---
Packages upgraded

- illuminate/support from "^7.0" to "^8.26.1"
- orchestra/testbench from "^5.0" to "^6.11.0"
- phpunit/phpunit from "^8.5" to "^9.5.2"
- 

Outcome
---
Laravel 8 compatibility