### PR TITLE
chore: update illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": "^7.4|^8.0",
     "ext-json": "*",
-    "illuminate/support": "^8.36",
+    "illuminate/support": "^8.0",
     "php-amqplib/php-amqplib": "v3.0"
   },
   "require-dev": {


### PR DESCRIPTION
As we are mentioning a specific version of `laravel/support` because of that it is causing conflict with different other packages.
So mentioning the latest version in `laravel/support` will solve the issue.