### PR TITLE
chore: update php-amqplib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": "^7.4|^8.0",
     "ext-json": "*",
     "illuminate/support": "^8.0",
-    "php-amqplib/php-amqplib": "v3.0"
+    "php-amqplib/php-amqplib": "v3.2"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
Description
---
- Current php-amqplib (v3.0) doesn't support php ^8.0 
- Update to v3.2 which has support for (php: ^7.1||^8.0)